### PR TITLE
Removed strtolower because caused an error

### DIFF
--- a/MySQL-Search-Replace/Class.MySQLSearchReplace.php
+++ b/MySQL-Search-Replace/Class.MySQLSearchReplace.php
@@ -128,7 +128,7 @@ class MySQLSearchReplace
         $this->getAllTables();
         // output in html table format
         $output    = "<tr><th>STATUS</th><th>ROWS AFFECTED</th><th>TABLE/FIELD</th><th>ERROR</th><th>QUERY</th></tr>";
-        $key       = 'Tables_in_' . strtolower($this->mysql_db);
+        $key       = 'Tables_in_' . $this->mysql_db;
         $occurence = 0;
         $no_of_tbl = count($this->tables);
         // scan each table each column except primary key column


### PR DESCRIPTION
With php72 on Redhat I used your script to search'n'replace strings in a mysql database. It caused 
Notice: Undefined index: Tables_in_databasename in /var/www/mysearchreplace/Class.MySQLSearchReplace.php on line 141
Fatal error: Uncaught Error: Call to a member function fetch_assoc() on boolean in /var/www/mysearchreplace/Class.MySQLSearchReplace.php:144
so i had to fix this line and it worked perfect
Maybe others would have this issue?